### PR TITLE
fix: make buttons unselectable

### DIFF
--- a/src/frontend/styles/application.scss
+++ b/src/frontend/styles/application.scss
@@ -91,6 +91,7 @@ pre {
 	right: 0px;
 	z-index: 1000;
 	width: 200px;
+	user-select: none;
 }
 
 #box1 {


### PR DESCRIPTION
This makes the top right buttons unselectable, so when I select all and copy, I don't get stuff like this:
```
Save
New
Duplicate & Edit
Just Text
```