### PR TITLE
fix: fix textarea height

### DIFF
--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -6,10 +6,16 @@
 	--dark-black: #141512;
 }
 
+html {
+	height: 100%;
+}
+
 body {
 	background: #282c34;
 	padding: 20px 50px;
 	margin: 0px;
+	height: 100%;
+	box-sizing: border-box;
 }
 
 /* textarea */


### PR DESCRIPTION
With the addition of the doctype tag in 9c766090916b0f3820d5a010fa8278efe7e51906, the input textarea's height is now fixed at two lines. You can reproduce this issue by typing more than two lines of text in the Hastebin. This pull request adds styling to address this problem.